### PR TITLE
fix: temporary disable discord auth

### DIFF
--- a/components/active/quiz/Results.vue
+++ b/components/active/quiz/Results.vue
@@ -85,67 +85,6 @@
             {{ t('page.quiz.result.download') }}
           </AtomsButton>
         </div>
-
-        <!-- Badge buttons -->
-        <div
-          v-if="response.isSubmitter"
-          class="mt-8 flex w-full flex-col items-center lg:mt-0 lg:w-1/3"
-        >
-          <p class="mb-4 text-gray-600">
-            {{ t('page.quiz.result.loginTitle') }}
-          </p>
-
-          <AtomsButton
-            v-if="response.isBadgeClaimed"
-            color="info"
-            class="py-2 px-6"
-          >
-            <span class="pr-2 normal-case">
-              {{ t('page.quiz.result.badgeClaimed') }}
-            </span>
-
-            <AtomsIcon
-              name="carbon:checkmark"
-              class="text-white"
-              width="2rem"
-              height="2rem"
-            />
-          </AtomsButton>
-          <AtomsButton
-            v-else-if="userSession"
-            color="gray"
-            class="bg-[#5865F2] py-2 px-6 text-white"
-            @click="$emit('claimBadge')"
-          >
-            <span class="pr-2 normal-case">
-              {{ t('page.quiz.result.claimBadge') }}
-            </span>
-
-            <AtomsIcon
-              name="carbon:logo-discord"
-              class="text-white"
-              width="2rem"
-              height="2rem"
-            />
-          </AtomsButton>
-          <AtomsButton
-            v-else
-            color="gray"
-            class="bg-[#5865F2] py-2 px-6 text-white"
-            @click="$emit('loginWithDiscord')"
-          >
-            <span class="pr-2 normal-case">
-              {{ t('page.quiz.result.loginButton') }}
-            </span>
-
-            <AtomsIcon
-              name="carbon:logo-discord"
-              class="text-white"
-              width="2rem"
-              height="2rem"
-            />
-          </AtomsButton>
-        </div>
       </div>
     </client-only>
 


### PR DESCRIPTION
Temporary remove the Discord Auth until we have the time to work on upgrading all the tokens, supabase oauth code, and other implementation needed. 

This allows us to be able to send out the quizzes to people who want to take the certification (primarily coming from workshops)
 
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
